### PR TITLE
Document GitHub Pages configuration requirements

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,56 @@
+# Deployment Configuration
+
+This application is deployed to GitHub Pages using GitHub Actions.
+
+## GitHub Pages Settings
+
+**Important**: GitHub Pages must be configured to use "GitHub Actions" as the source, not "Deploy from branch".
+
+### Required Configuration
+1. Go to repository Settings → Pages
+2. Under "Source", select **GitHub Actions** (not "Deploy from branch")
+3. Save the changes
+
+### Why This Matters
+- The build process creates optimized files in the `dist/` directory
+- GitHub Actions deployment serves these built files
+- "Deploy from branch" would serve raw source files, breaking the React application
+
+## Deployment Process
+
+1. **Automatic Deployment**: Every push to `main` triggers the deployment workflow
+2. **Build**: Vite builds the React application with proper base paths
+3. **Deploy**: GitHub Actions uploads the `dist/` folder to GitHub Pages
+
+## Verification
+
+After deployment, verify the site works at: https://policyengine.github.io/policy-library/
+
+You should see:
+- PolicyEngine logo in navigation
+- Navigation items: Overview, Mock-up, Partners, PBIF Application, Community, ENG(INE) Application
+- Interactive demo functionality
+- All CSS styling properly applied
+
+## Troubleshooting
+
+If you see raw HTML or "module not found" errors:
+1. Check GitHub Pages is set to "GitHub Actions" source
+2. Wait 5-10 minutes for caches to clear
+3. Check the Actions tab for deployment status
+
+## Local Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Preview production build
+npm run preview
+```

--- a/README.md
+++ b/README.md
@@ -1,69 +1,79 @@
-# React + TypeScript + Vite
+# PolicyEngine Policy Library
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+AI-powered infrastructure for preserving and serving America's safety net policy documents.
 
-Currently, two official plugins are available:
+## Overview
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+The Policy Library addresses a critical infrastructure failure: benefit program documents disappear constantly. Our analysis shows 18% of benefit program URLs from 2019 are dead today. This system uses AI-powered crawlers to monitor 50+ jurisdictions, capturing statutes, regulations, and forms before they vanish.
 
-## Expanding the ESLint configuration
+**Live Application**: https://policyengine.github.io/policy-library/
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## Features
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+- **AI-Powered Document Crawling**: Claude/GPT-4 powered intelligent extraction
+- **Permanent Archive**: Version-controlled documents with stable source IDs
+- **MCP Server Integration**: Native AI assistant support for accurate policy lookups
+- **REST API**: Simple endpoints for document access
+- **Community Maintained**: Civic tech groups help maintain jurisdiction coverage
 
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
+## Development
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+# Install dependencies
+npm install
+
+# Start development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Run tests
+npm test
+
+# Lint and format
+npm run lint -- --fix
+npx prettier --write .
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Deployment
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+This site is automatically deployed to GitHub Pages when changes are pushed to the `main` branch.
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+**Important**: GitHub Pages must be configured to use "GitHub Actions" as the source. See [DEPLOYMENT.md](DEPLOYMENT.md) for configuration details.
+
+## Project Structure
+
 ```
+src/
+├── components/
+│   ├── Overview.tsx              # Main landing page
+│   ├── Demo.tsx                  # Interactive mock-up
+│   ├── Partners.tsx              # Partner organizations
+│   ├── PBIFApplication.tsx       # PBIF grant application
+│   ├── CivicTechEngagement.tsx  # Community involvement
+│   └── ENGINEApplication.tsx     # ENGINE nonprofit application
+├── App.tsx                       # Main application component
+└── App.css                       # Global styles
+```
+
+## Technology Stack
+
+- **Frontend**: React + TypeScript + Vite
+- **Styling**: CSS with PolicyEngine design system
+- **Deployment**: GitHub Pages via GitHub Actions
+- **CI/CD**: GitHub Actions for testing and deployment
+
+## Contributing
+
+We welcome contributions from civic technologists! See our [Community page](https://policyengine.github.io/policy-library/#civic-tech) for ways to get involved.
+
+## License
+
+Public domain (Unlicense) - This is public infrastructure for public benefit.
+
+## Contact
+
+Max Ghenis, CEO - max@policyengine.org
+
+**Application Deadline**: August 16, 2025, 11:59 PM PT


### PR DESCRIPTION
## Summary

Documents the GitHub Pages configuration that was just fixed to make the site work properly.

## Context

The site wasn't working because GitHub Pages was set to "Deploy from branch" (legacy mode) instead of "GitHub Actions". This caused it to serve the raw source files instead of the built React application.

## Changes

- Added **DEPLOYMENT.md** with clear configuration instructions
- Replaced default Vite README with proper project documentation
- Documented the GitHub Actions requirement
- Added troubleshooting steps for future developers

## Verification

The site now works correctly at: https://policyengine.github.io/policy-library/

You should see:
- PolicyEngine logo
- Full navigation including the new Community section
- Interactive demo functionality
- All styling properly applied