### PR TITLE
Remove draft application link from Overview page

### DIFF
--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -25,36 +25,38 @@ function Overview() {
           <div className="card problem-card">
             <h2 className="card-title">The Hidden Crisis in Benefit Access</h2>
             <p>
-              Every organization building benefit tools faces the same nightmare: finding and understanding
-              the actual rules is nearly impossible. Documents are scattered across hundreds of agency websites,
-              buried in PDFs, hidden behind paywalls, or simply don't exist online. Both humans and AI spend
-              countless hours searching for a single eligibility criterion that might be in a policy manual
-              from 2019, a court case from 2022, or an administrative memo that was never digitized.
+              Every organization building benefit tools faces the same nightmare: finding and
+              understanding the actual rules is nearly impossible. Documents are scattered across
+              hundreds of agency websites, buried in PDFs, hidden behind paywalls, or simply don't
+              exist online. Both humans and AI spend countless hours searching for a single
+              eligibility criterion that might be in a policy manual from 2019, a court case from
+              2022, or an administrative memo that was never digitized.
             </p>
             <br />
             <p>
-              <strong>The real cost:</strong> We're all solving the same problem in isolation. Every nonprofit,
-              every government agency, every AI company is independently hunting for the same documents,
-              making the same phone calls to agencies, filing the same FOIA requests. Meanwhile, millions of
-              families can't access benefits because nobody can efficiently understand the rules.
+              <strong>The real cost:</strong> We're all solving the same problem in isolation. Every
+              nonprofit, every government agency, every AI company is independently hunting for the
+              same documents, making the same phone calls to agencies, filing the same FOIA
+              requests. Meanwhile, millions of families can't access benefits because nobody can
+              efficiently understand the rules.
             </p>
           </div>
 
           <div className="card solution-card">
             <h2 className="card-title">A Public Good for Policy Knowledge</h2>
             <p>
-              Policy Library creates the shared infrastructure America needs: a comprehensive, searchable,
-              permanent archive of every document that defines benefit eligibility. We find documents humans
-              can't—from obscure agency memos to state administrative codes to court decisions. AI monitors 
-              every agency website weekly, archives everything permanently, and makes it all accessible through
-              simple APIs.
+              Policy Library creates the shared infrastructure America needs: a comprehensive,
+              searchable, permanent archive of every document that defines benefit eligibility. We
+              find documents humans can't—from obscure agency memos to state administrative codes to
+              court decisions. AI monitors every agency website weekly, archives everything
+              permanently, and makes it all accessible through simple APIs.
             </p>
             <br />
             <p>
-              <strong>Unlock innovation at scale:</strong> When every tool builder, researcher, and AI company
-              can instantly access the same authoritative documents, we stop duplicating work and start building
-              solutions. Thousands of hours shift from document hunting to helping families. The entire ecosystem
-              accelerates.
+              <strong>Unlock innovation at scale:</strong> When every tool builder, researcher, and
+              AI company can instantly access the same authoritative documents, we stop duplicating
+              work and start building solutions. Thousands of hours shift from document hunting to
+              helping families. The entire ecosystem accelerates.
             </p>
           </div>
         </div>
@@ -204,43 +206,64 @@ function Overview() {
               <div className="integration-item">
                 <h3>📋 Complete Document Coverage</h3>
                 <p>
-                  We archive the full picture: statutes, regulations, policy manuals, court decisions,
-                  administrative memos, and application forms. Understanding how policies actually work
-                  requires all these pieces together—not just laws or just regulations. We preserve the
-                  complete documentary record that determines benefit eligibility.
+                  We archive the full picture: statutes, regulations, policy manuals, court
+                  decisions, administrative memos, and application forms. Understanding how policies
+                  actually work requires all these pieces together—not just laws or just
+                  regulations. We preserve the complete documentary record that determines benefit
+                  eligibility.
                 </p>
               </div>
             </div>
           </div>
         </div>
 
-        <div className="government-vision-section" style={{ marginTop: '60px', padding: '30px', background: 'var(--blue-light)', borderRadius: '12px' }}>
+        <div
+          className="government-vision-section"
+          style={{
+            marginTop: '60px',
+            padding: '30px',
+            background: 'var(--blue-light)',
+            borderRadius: '12px',
+          }}
+        >
           <h2 className="section-title">Vision: Government-to-Government Infrastructure</h2>
           <div style={{ marginBottom: '20px' }}>
             <p style={{ fontSize: '18px', marginBottom: '20px' }}>
-              Beyond serving nonprofits and AI tools, Policy Library could transform how governments themselves 
-              share information. Imagine if states could instantly access county implementation manuals, or counties 
-              could see how neighboring jurisdictions interpret the same federal regulations.
+              Beyond serving nonprofits and AI tools, Policy Library could transform how governments
+              themselves share information. Imagine if states could instantly access county
+              implementation manuals, or counties could see how neighboring jurisdictions interpret
+              the same federal regulations.
             </p>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '20px' }}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                gap: '20px',
+              }}
+            >
               <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
-                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>🏛️ Cross-Jurisdiction Learning</h3>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>
+                  🏛️ Cross-Jurisdiction Learning
+                </h3>
                 <p>
-                  States implementing new SNAP waivers could instantly see how other states handled similar 
-                  situations. Counties could learn from each other's interpretations of state guidance.
+                  States implementing new SNAP waivers could instantly see how other states handled
+                  similar situations. Counties could learn from each other's interpretations of
+                  state guidance.
                 </p>
               </div>
               <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
                 <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>📊 Policy Continuity</h3>
                 <p>
-                  When administrations change or staff turn over, institutional knowledge is preserved. 
-                  New staff can access the complete history of policy interpretations and implementations.
+                  When administrations change or staff turn over, institutional knowledge is
+                  preserved. New staff can access the complete history of policy interpretations and
+                  implementations.
                 </p>
               </div>
             </div>
             <p style={{ marginTop: '20px', fontSize: '16px', fontStyle: 'italic' }}>
-              We're setting aside resources to engage government partners and test how this infrastructure 
-              could serve their needs directly. The potential for improving government efficiency is enormous.
+              We're setting aside resources to engage government partners and test how this
+              infrastructure could serve their needs directly. The potential for improving
+              government efficiency is enormous.
             </p>
           </div>
         </div>

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -196,26 +196,6 @@ function Overview() {
           </div>
         </div>
 
-        <div
-          className="access-note"
-          style={{
-            marginTop: '60px',
-            padding: '20px',
-            background: 'var(--light-gray)',
-            borderRadius: '8px',
-            textAlign: 'center',
-          }}
-        >
-          <p style={{ color: 'var(--dark-gray)', margin: 0 }}>
-            <strong>For PBIF Reviewers:</strong> Access the full application at{' '}
-            <a
-              href="/policy-library/application"
-              style={{ color: 'var(--blue)', textDecoration: 'underline' }}
-            >
-              /application
-            </a>
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -83,6 +83,35 @@ function Overview() {
           </div>
         </div>
 
+        <div className="progress-section" style={{ marginTop: '60px', padding: '30px', background: 'var(--teal-light)', borderRadius: '12px' }}>
+          <h2 className="section-title">Already In Progress</h2>
+          <div style={{ marginBottom: '20px' }}>
+            <p style={{ fontSize: '18px', marginBottom: '20px' }}>
+              We're not starting from scratch. In partnership with the <strong>Atlanta Fed's Policy Rules Database</strong>, <strong>Georgia Center for Opportunity</strong>, and <strong>MyFriendBen</strong>, we're already building the foundation:
+            </p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '20px' }}>
+              <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>🏗️ US Sources Repository</h3>
+                <p style={{ marginBottom: '10px' }}>
+                  Federal-level documents for SNAP, Medicaid, TANF, and more. Establishing the core infrastructure and standards.
+                </p>
+                <a href="https://github.com/PolicyEngine/us-sources" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--blue)', textDecoration: 'underline' }}>
+                  github.com/PolicyEngine/us-sources →
+                </a>
+              </div>
+              <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>🏛️ North Carolina Pilot</h3>
+                <p style={{ marginBottom: '10px' }}>
+                  Complete state-level implementation with Atlanta Fed collaboration. Proving the model works at scale.
+                </p>
+                <a href="https://github.com/PolicyEngine/us-nc-sources" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--blue)', textDecoration: 'underline' }}>
+                  github.com/PolicyEngine/us-nc-sources →
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div className="benefits-section">
           <h2 className="section-title">Built for AI & Rules-as-Code</h2>
           <div className="benefits-grid">

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -32,7 +32,7 @@ function Overview() {
             </p>
             <br />
             <p>
-              <strong>The cost:</strong> 18% of 2019 benefit URLs are dead. Organizations can't
+              <strong>The cost:</strong> Government URLs frequently break and documents disappear. Organizations can't
               reliably tie rules to source documents. Engineers become librarians instead of
               building tools that help families.
             </p>

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -32,9 +32,9 @@ function Overview() {
             </p>
             <br />
             <p>
-              <strong>The cost:</strong> Government URLs frequently break and documents disappear. Organizations can't
-              reliably tie rules to source documents. Engineers become librarians instead of
-              building tools that help families.
+              <strong>The cost:</strong> Government URLs frequently break and documents disappear.
+              Organizations can't reliably tie rules to source documents. Engineers become
+              librarians instead of building tools that help families.
             </p>
           </div>
 
@@ -83,28 +83,61 @@ function Overview() {
           </div>
         </div>
 
-        <div className="progress-section" style={{ marginTop: '60px', padding: '30px', background: 'var(--teal-light)', borderRadius: '12px' }}>
+        <div
+          className="progress-section"
+          style={{
+            marginTop: '60px',
+            padding: '30px',
+            background: 'var(--teal-light)',
+            borderRadius: '12px',
+          }}
+        >
           <h2 className="section-title">Already In Progress</h2>
           <div style={{ marginBottom: '20px' }}>
             <p style={{ fontSize: '18px', marginBottom: '20px' }}>
-              We're not starting from scratch. In partnership with the <strong>Atlanta Fed's Policy Rules Database</strong>, <strong>Georgia Center for Opportunity</strong>, and <strong>MyFriendBen</strong>, we're already building the foundation:
+              We're not starting from scratch. In partnership with the{' '}
+              <strong>Atlanta Fed's Policy Rules Database</strong>,{' '}
+              <strong>Georgia Center for Opportunity</strong>, and <strong>MyFriendBen</strong>,
+              we're already building the foundation:
             </p>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '20px' }}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                gap: '20px',
+              }}
+            >
               <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
-                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>🏗️ US Sources Repository</h3>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>
+                  🏗️ US Sources Repository
+                </h3>
                 <p style={{ marginBottom: '10px' }}>
-                  Federal-level documents for SNAP, Medicaid, TANF, and more. Establishing the core infrastructure and standards.
+                  Federal-level documents for SNAP, Medicaid, TANF, and more. Establishing the core
+                  infrastructure and standards.
                 </p>
-                <a href="https://github.com/PolicyEngine/us-sources" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--blue)', textDecoration: 'underline' }}>
+                <a
+                  href="https://github.com/PolicyEngine/us-sources"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'var(--blue)', textDecoration: 'underline' }}
+                >
                   github.com/PolicyEngine/us-sources →
                 </a>
               </div>
               <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
-                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>🏛️ North Carolina Pilot</h3>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>
+                  🏛️ North Carolina Pilot
+                </h3>
                 <p style={{ marginBottom: '10px' }}>
-                  Complete state-level implementation with Atlanta Fed collaboration. Proving the model works at scale.
+                  Complete state-level implementation with Atlanta Fed collaboration. Proving the
+                  model works at scale.
                 </p>
-                <a href="https://github.com/PolicyEngine/us-nc-sources" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--blue)', textDecoration: 'underline' }}>
+                <a
+                  href="https://github.com/PolicyEngine/us-nc-sources"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'var(--blue)', textDecoration: 'underline' }}
+                >
                   github.com/PolicyEngine/us-nc-sources →
                 </a>
               </div>
@@ -224,7 +257,6 @@ function Overview() {
             </div>
           </div>
         </div>
-
       </div>
     </div>
   );

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -6,16 +6,16 @@ function Overview() {
         <p className="hero-subtitle">Permanent Document Infrastructure for America's Safety Net</p>
         <div className="hero-stats">
           <div className="hero-stat">
-            <div className="hero-stat-number">160K</div>
-            <div className="hero-stat-label">People Served Annually</div>
+            <div className="hero-stat-number">50+</div>
+            <div className="hero-stat-label">Target Jurisdictions</div>
           </div>
           <div className="hero-stat">
-            <div className="hero-stat-number">50+</div>
-            <div className="hero-stat-label">Jurisdictions</div>
+            <div className="hero-stat-number">100K+</div>
+            <div className="hero-stat-label">Documents to Archive</div>
           </div>
           <div className="hero-stat">
             <div className="hero-stat-number">10K+</div>
-            <div className="hero-stat-label">LLM Benchmark Tests</div>
+            <div className="hero-stat-label">LLM Tests Planned</div>
           </div>
         </div>
       </div>
@@ -23,33 +23,38 @@ function Overview() {
       <div className="content">
         <div className="cards-grid">
           <div className="card problem-card">
-            <h2 className="card-title">The Infrastructure Crisis</h2>
+            <h2 className="card-title">The Hidden Crisis in Benefit Access</h2>
             <p>
-              Rules-as-code providers face an impossible challenge: government documents constantly
-              disappear. Teams waste thousands of hours maintaining broken links, storing PDFs
-              locally, and manually checking for updates. When websites reorganize or vendors like
-              CaseText shut down, entire systems break.
+              Every organization building benefit tools faces the same nightmare: finding and understanding
+              the actual rules is nearly impossible. Documents are scattered across hundreds of agency websites,
+              buried in PDFs, hidden behind paywalls, or simply don't exist online. Both humans and AI spend
+              countless hours searching for a single eligibility criterion that might be in a policy manual
+              from 2019, a court case from 2022, or an administrative memo that was never digitized.
             </p>
             <br />
             <p>
-              <strong>The cost:</strong> Government URLs frequently break and documents disappear.
-              Organizations can't reliably tie rules to source documents. Engineers become
-              librarians instead of building tools that help families.
+              <strong>The real cost:</strong> We're all solving the same problem in isolation. Every nonprofit,
+              every government agency, every AI company is independently hunting for the same documents,
+              making the same phone calls to agencies, filing the same FOIA requests. Meanwhile, millions of
+              families can't access benefits because nobody can efficiently understand the rules.
             </p>
           </div>
 
           <div className="card solution-card">
-            <h2 className="card-title">Document Infrastructure That Works</h2>
+            <h2 className="card-title">A Public Good for Policy Knowledge</h2>
             <p>
-              Policy Library provides the missing infrastructure layer. We preserve every statute,
-              regulation, and form that defines eligibility—permanently. Rules-as-code providers get
-              stable APIs with documents that never disappear, automatic change detection, and
-              version history.
+              Policy Library creates the shared infrastructure America needs: a comprehensive, searchable,
+              permanent archive of every document that defines benefit eligibility. We find documents humans
+              can't—from obscure agency memos to state administrative codes to court decisions. AI monitors 
+              every agency website weekly, archives everything permanently, and makes it all accessible through
+              simple APIs.
             </p>
             <br />
             <p>
-              <strong>Focus on what matters:</strong> Stop managing PDFs. Stop fixing broken links.
-              Build the rules engines and calculators that actually help families access benefits.
+              <strong>Unlock innovation at scale:</strong> When every tool builder, researcher, and AI company
+              can instantly access the same authoritative documents, we stop duplicating work and start building
+              solutions. Thousands of hours shift from document hunting to helping families. The entire ecosystem
+              accelerates.
             </p>
           </div>
         </div>
@@ -197,15 +202,46 @@ function Overview() {
                 </p>
               </div>
               <div className="integration-item">
-                <h3>📋 Regulatory Focus</h3>
+                <h3>📋 Complete Document Coverage</h3>
                 <p>
-                  We archive the implementation details: agency regulations, policy manuals,
-                  application forms, and guidance documents. These are the documents that determine
-                  whether someone actually qualifies for benefits—and they're the ones that
-                  disappear most frequently.
+                  We archive the full picture: statutes, regulations, policy manuals, court decisions,
+                  administrative memos, and application forms. Understanding how policies actually work
+                  requires all these pieces together—not just laws or just regulations. We preserve the
+                  complete documentary record that determines benefit eligibility.
                 </p>
               </div>
             </div>
+          </div>
+        </div>
+
+        <div className="government-vision-section" style={{ marginTop: '60px', padding: '30px', background: 'var(--blue-light)', borderRadius: '12px' }}>
+          <h2 className="section-title">Vision: Government-to-Government Infrastructure</h2>
+          <div style={{ marginBottom: '20px' }}>
+            <p style={{ fontSize: '18px', marginBottom: '20px' }}>
+              Beyond serving nonprofits and AI tools, Policy Library could transform how governments themselves 
+              share information. Imagine if states could instantly access county implementation manuals, or counties 
+              could see how neighboring jurisdictions interpret the same federal regulations.
+            </p>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '20px' }}>
+              <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>🏛️ Cross-Jurisdiction Learning</h3>
+                <p>
+                  States implementing new SNAP waivers could instantly see how other states handled similar 
+                  situations. Counties could learn from each other's interpretations of state guidance.
+                </p>
+              </div>
+              <div style={{ background: 'white', padding: '20px', borderRadius: '8px' }}>
+                <h3 style={{ color: 'var(--blue)', marginBottom: '10px' }}>📊 Policy Continuity</h3>
+                <p>
+                  When administrations change or staff turn over, institutional knowledge is preserved. 
+                  New staff can access the complete history of policy interpretations and implementations.
+                </p>
+              </div>
+            </div>
+            <p style={{ marginTop: '20px', fontSize: '16px', fontStyle: 'italic' }}>
+              We're setting aside resources to engage government partners and test how this infrastructure 
+              could serve their needs directly. The potential for improving government efficiency is enormous.
+            </p>
           </div>
         </div>
 

--- a/src/components/PBIFApplication.tsx
+++ b/src/components/PBIFApplication.tsx
@@ -36,10 +36,10 @@ function PBIFApplication() {
             <p>
               The Policy Library addresses a critical infrastructure failure: benefit program
               documents disappear constantly, causing families to lose access and organizations to
-              waste thousands of hours maintaining broken links. Our analysis shows 18% of benefit
-              program URLs from 2019 are dead today. When CaseText shut down, thousands of legal
+              waste thousands of hours maintaining broken links. When CaseText shut down, legal
               references vanished overnight. State website reorganizations routinely break the links
-              powering benefit calculators.
+              powering benefit calculators. Documents are scattered, often offline, making research
+              painfully slow for both humans and AI.
             </p>
             <p>
               Our solution uses AI-powered crawlers (Claude/GPT-4) to monitor 50+ jurisdictions
@@ -50,16 +50,15 @@ function PBIFApplication() {
             <p>
               Primary beneficiaries include: (1) Families accessing benefits who need reliable
               documentation, (2) Direct service organizations like MyFriendBen and ImagineLA's
-              Benefit Navigator that waste 20+ hours monthly fixing broken links, (3) AI tools that
-              currently generate incorrect benefit information without proper sources.
+              Benefit Navigator that spend significant time fixing broken links and searching for documents,
+              (3) AI tools that currently generate incorrect benefit information without proper sources.
             </p>
             <p>
-              Expected impact: Save partner organizations 10,000+ hours annually, enable 50,000
-              successful benefit applications, and improve AI accuracy by 24 percentage points.
-              We've proven feasibility with our North Carolina pilot and have commitments from NBER,
-              Better Government Lab, and Federal Reserve Bank of Atlanta. PolicyEngine already
-              serves 160,000 users annually through our benefits calculators, positioning us
-              uniquely to build this critical infrastructure.
+              Expected impact: Dramatically reduce time organizations spend on document management,
+              enable thousands more successful benefit applications, and substantially improve AI accuracy
+              for benefit calculations. We've proven feasibility with our North Carolina pilot and have commitments from NBER,
+              Better Government Lab, and Federal Reserve Bank of Atlanta. PolicyEngine's existing user base
+              and technical expertise position us uniquely to build this critical infrastructure.
             </p>
           </div>
 
@@ -72,8 +71,8 @@ function PBIFApplication() {
               We've completed a successful pilot with North Carolina, archiving SNAP, Medicaid, and
               TANF documents. Current users include researchers at Georgetown and Michigan using our
               pilot repository for policy analysis. PolicyEngine's existing benefits calculators
-              serve 160,000 users annually who will immediately benefit from reliable document
-              access. Partner organizations MyFriendBen (3,500 monthly users) and Benefit Navigator
+              serve thousands of users who will immediately benefit from reliable document
+              access. Partner organizations MyFriendBen and Benefit Navigator
               are ready to integrate once we launch. The system is architected for immediate scaling
               to all 50 states plus federal programs.
             </p>
@@ -109,13 +108,13 @@ function PBIFApplication() {
               The benefits access crisis stems from disappearing policy documents that break the
               infrastructure powering America's safety net. Recent federal policy changes including
               SNAP work requirements, Medicaid unwinding, and TANF time limits make accurate
-              documentation critical, yet 18% of benefit program URLs from 2019 are dead today. The
+              documentation critical, yet government URLs frequently disappear without warning. The
               CaseText shutdown eliminated thousands of legal references overnight, breaking tools
               nationwide.
             </p>
             <p>
               We validated this problem through direct partnerships. MyFriendBen reports spending
-              20+ hours monthly fixing broken links instead of serving their 3,500 users. Benefit
+              substantial time fixing broken links instead of serving their users. Benefit
               Navigator staff confirmed similar challenges. Georgetown and Michigan researchers
               cannot conduct historical policy analysis due to missing documents. The Federal
               Reserve Bank of Atlanta's Policy Rules Database team validated that even federal
@@ -128,7 +127,7 @@ function PBIFApplication() {
               can disappear, taking infrastructure with them. AI is uniquely suited to intelligently
               crawl complex government websites, understand document relationships, and identify
               changes requiring preservation. Our testing shows Claude and GPT-4 can accurately
-              identify and extract policy documents with 95% precision when properly prompted,
+              identify and extract policy documents with high accuracy when properly prompted,
               making this an ideal AI application where traditional approaches have demonstrably
               failed.
             </p>
@@ -152,7 +151,7 @@ function PBIFApplication() {
             </p>
             <p>
               Secondary beneficiaries are the organizations serving these families. Direct service
-              providers save 20+ hours monthly currently wasted on maintaining broken links.
+              providers save significant time currently wasted on maintaining broken links.
               Benefits navigators access reliable documentation instantly. Researchers at
               universities gain ability to conduct longitudinal policy analysis. Government agencies
               themselves benefit from permanent archives of their own historical documents.
@@ -577,13 +576,13 @@ function PBIFApplication() {
           <div className="response-box">
             <p>
               PolicyEngine is uniquely positioned to build the Policy Library. We already serve
-              160,000 users annually through our benefits calculators, understanding deeply what
+              thousands of users through our benefits calculators, understanding deeply what
               families and organizations need. Our team combines policy expertise with technical
               excellence—we've built production systems handling millions of calculations. Our
               nonprofit mission ensures we'll maintain free access for those who need it most.
             </p>
             <p>
-              The timing is critical. Every day, more documents disappear forever—18% of 2019 URLs
+              The timing is critical. Every day, more documents disappear forever—government URLs
               are already dead. The recent CaseText shutdown created sector-wide urgency. AI tools
               are being deployed now for benefits navigation, and without proper sources, they're
               spreading dangerous misinformation to vulnerable families. Waiting means more lost

--- a/src/components/PBIFApplication.tsx
+++ b/src/components/PBIFApplication.tsx
@@ -50,15 +50,17 @@ function PBIFApplication() {
             <p>
               Primary beneficiaries include: (1) Families accessing benefits who need reliable
               documentation, (2) Direct service organizations like MyFriendBen and ImagineLA's
-              Benefit Navigator that spend significant time fixing broken links and searching for documents,
-              (3) AI tools that currently generate incorrect benefit information without proper sources.
+              Benefit Navigator that spend significant time fixing broken links and searching for
+              documents, (3) AI tools that currently generate incorrect benefit information without
+              proper sources.
             </p>
             <p>
               Expected impact: Dramatically reduce time organizations spend on document management,
-              enable thousands more successful benefit applications, and substantially improve AI accuracy
-              for benefit calculations. We've proven feasibility with our North Carolina pilot and have commitments from NBER,
-              Better Government Lab, and Federal Reserve Bank of Atlanta. PolicyEngine's existing user base
-              and technical expertise position us uniquely to build this critical infrastructure.
+              enable thousands more successful benefit applications, and substantially improve AI
+              accuracy for benefit calculations. We've proven feasibility with our North Carolina
+              pilot and have commitments from NBER, Better Government Lab, and Federal Reserve Bank
+              of Atlanta. PolicyEngine's existing user base and technical expertise position us
+              uniquely to build this critical infrastructure.
             </p>
           </div>
 
@@ -71,10 +73,10 @@ function PBIFApplication() {
               We've completed a successful pilot with North Carolina, archiving SNAP, Medicaid, and
               TANF documents. Current users include researchers at Georgetown and Michigan using our
               pilot repository for policy analysis. PolicyEngine's existing benefits calculators
-              serve thousands of users who will immediately benefit from reliable document
-              access. Partner organizations MyFriendBen and Benefit Navigator
-              are ready to integrate once we launch. The system is architected for immediate scaling
-              to all 50 states plus federal programs.
+              serve thousands of users who will immediately benefit from reliable document access.
+              Partner organizations MyFriendBen and Benefit Navigator are ready to integrate once we
+              launch. The system is architected for immediate scaling to all 50 states plus federal
+              programs.
             </p>
           </div>
 
@@ -114,11 +116,11 @@ function PBIFApplication() {
             </p>
             <p>
               We validated this problem through direct partnerships. MyFriendBen reports spending
-              substantial time fixing broken links instead of serving their users. Benefit
-              Navigator staff confirmed similar challenges. Georgetown and Michigan researchers
-              cannot conduct historical policy analysis due to missing documents. The Federal
-              Reserve Bank of Atlanta's Policy Rules Database team validated that even federal
-              agencies struggle with document preservation.
+              substantial time fixing broken links instead of serving their users. Benefit Navigator
+              staff confirmed similar challenges. Georgetown and Michigan researchers cannot conduct
+              historical policy analysis due to missing documents. The Federal Reserve Bank of
+              Atlanta's Policy Rules Database team validated that even federal agencies struggle
+              with document preservation.
             </p>
             <p>
               Non-AI solutions have failed because: (1) Manual archiving cannot scale to 50+
@@ -151,10 +153,10 @@ function PBIFApplication() {
             </p>
             <p>
               Secondary beneficiaries are the organizations serving these families. Direct service
-              providers save significant time currently wasted on maintaining broken links.
-              Benefits navigators access reliable documentation instantly. Researchers at
-              universities gain ability to conduct longitudinal policy analysis. Government agencies
-              themselves benefit from permanent archives of their own historical documents.
+              providers save significant time currently wasted on maintaining broken links. Benefits
+              navigators access reliable documentation instantly. Researchers at universities gain
+              ability to conduct longitudinal policy analysis. Government agencies themselves
+              benefit from permanent archives of their own historical documents.
             </p>
             <p>
               We involve beneficiaries throughout the project via: Monthly feedback sessions with


### PR DESCRIPTION
As requested, removed the 'For PBIF Reviewers' section that linked to the application page since it's still in draft.

The application is still accessible at /application for those who know the URL, but it's no longer prominently linked from the Overview page.