### PR TITLE
Add word counts to PBIF application sections

### DIFF
--- a/src/content/pbif/01-executive-summary.md
+++ b/src/content/pbif/01-executive-summary.md
@@ -11,6 +11,8 @@ PolicyEngine Policy Library
 ## Executive Summary (limit 250 words)
 *"In a concise summary, describe the core problem your project addresses, the proposed technical solution, the target beneficiaries, and the anticipated impact."*
 
+**Word Count: 192/250**
+
 The Policy Library creates infrastructure transforming benefits delivery. When tools access comprehensive source documents, we enable: AI accurately determining multi-program eligibility, caseworkers confidently navigating rules, researchers tracking policy variations, and innovations we haven't imagined.
 
 We combine AI-powered monitoring (Claude/GPT-5) with PolicyEngine's open-source rules engine. We understand document relationships, surface non-obvious connections (TANF-SNAP categorical eligibility), enabling tools to build on authoritative ground truth.

--- a/src/content/pbif/02-value-proposition.md
+++ b/src/content/pbif/02-value-proposition.md
@@ -3,6 +3,8 @@
 ## Problem Statement (250 words)
 *"Clearly articulate the specific problem or challenge your initiative aims to address and how it relates to recent changes in federal policy or funding changes. Provide supporting data or evidence to demonstrate the urgency and significance of this problem - and how you've validated it with staff and/or beneficiaries. Is this an area where non-AI solutions do not already offer effective, fit-for-purpose, affordable approaches?"*
 
+**Word Count: 220/250**
+
 The benefits ecosystem lacks infrastructure for policy documentation, forcing organizations to rebuild document discovery. This prevents innovations: AI can't provide accurate multi-program guidance, caseworkers can't navigate eligibility rules, researchers can't track policy evolution. Recent changes—SNAP work requirements, Medicaid unwinding, TANF limits—make this critical.
 
 Partners validated this need. MyFriendBen and Benefit Navigator waste resources maintaining documents. Georgetown and Michigan researchers lack document foundations. Atlanta Fed's collaboration shows even sophisticated institutions need shared infrastructure. Families face inconsistent information without comprehensive documentation.
@@ -10,6 +12,8 @@ Partners validated this need. MyFriendBen and Benefit Navigator waste resources 
 Archive.org can't solve this: captures pages indiscriminately without understanding policy documents, no API for "Colorado SNAP rules" queries, can't identify document relationships, no metadata or semantic search. Benefits platforms need purpose-built infrastructure—structured data, reliable APIs, intelligent understanding. AI uniquely enables: (1) Intelligent crawling understands which documents matter, (2) LLMs identify changes requiring preservation, (3) AI surfaces non-obvious connections like TANF-SNAP categorical eligibility. Claude and GPT-5 excel at document extraction. This infrastructure amplifies human expertise, enabling impossible innovations.
 
 ## Solution & Target Beneficiaries (250 words)
+
+**Word Count: 244/250**
 
 The Policy Library solves document disappearance through three integrated components: (1) AI-powered crawlers using Claude/GPT-5 intelligently monitor government websites weekly, understanding context and document relationships; (2) Humans verify accuracy through GitHub pull requests; (3) Our stable API serves documents with permanent source IDs that never break. We'll launch with 5,000+ documents pooled from all participating organizations—PolicyEngine, Atlanta Fed, GCO, NBER (via TAXSIM MOU), Prenatal-to-3 Policy Impact Center at Vanderbilt, Better Government Lab, USC, MyFriendBen, and Benefit Navigator—ensuring comprehensive coverage from day one.
 
@@ -20,6 +24,8 @@ Organizations serving these families also benefit significantly. Direct service 
 We involve beneficiaries throughout the project via: Monthly feedback sessions with partner organizations, open GitHub discussions for document requests, public dashboards showing coverage gaps, and direct integration with tools families already use. This participatory approach ensures we're building infrastructure that serves real needs, not theoretical ones.
 
 ## Proposed Benefit and Impact Evaluation (250 words)
+
+**Word Count: 181/250**
 
 Our success transforms how America's safety net operates. Organizations shift from maintaining broken links to serving families. AI tools provide accurate benefit information. Families never lose benefits due to missing documents.
 
@@ -35,6 +41,8 @@ We track progress through automated dashboards, monthly partner surveys, and API
 
 ## Responsible Design and Use (250 words)
 
+**Word Count: 192/250**
+
 We identify three key risks: privacy concerns, accuracy issues, and potential misuse. We address each proactively through technical and governance measures.
 
 **Privacy protection:** We archive only publicly available documents, never personal data. We don't collect or store user information. All documents we preserve already exist publicly. We respect robots.txt restrictions and rate limits to avoid overloading government servers.
@@ -47,6 +55,8 @@ We identify three key risks: privacy concerns, accuracy issues, and potential mi
 
 ## Adoption and Path to Scale (250 words)
 
+**Word Count: 238/250**
+
 Implementation builds on existing relationships. MyFriendBen already uses our API for 3,500+ monthly benefit calculations across Colorado—we'll add document display to these existing requests, showing users the actual regulations behind their results. Benefit Navigator, deployed with LA County caseworkers and expanding to Riverside County, will enhance their current PolicyEngine integration with primary-source verification during eligibility determinations. Each pilot receives $30k for deep technical integration and deployment support.
 
 Government partnership strategy leverages existing relationships. Federal Reserve Bank of Atlanta has committed to collaboration through their Policy Rules Database. North Carolina and California agencies expressed interest following our pilot success. We'll formalize partnerships through MOUs establishing data sharing agreements and technical integration plans.
@@ -58,6 +68,8 @@ Sustainability comes through diversified support. Enterprise API subscriptions f
 Scalability is built into architecture. Cloud infrastructure handles growth automatically. Crawler architecture is jurisdiction-agnostic, adding new states requires configuration not code. Community contributors can add coverage through pull requests. By Month 24, we'll cover all 50 states plus federal programs, becoming essential infrastructure for America's safety net.
 
 ## Dissemination & Learning (250 words)
+
+**Word Count: 167/250**
 
 Knowledge sharing maximizes impact across the benefits ecosystem.
 

--- a/src/content/pbif/03-technical-feasibility.md
+++ b/src/content/pbif/03-technical-feasibility.md
@@ -2,6 +2,8 @@
 
 ## Solution Description (250 words)
 
+**Word Count: 198/250**
+
 AI crawlers understand government websites like human researchers. Claude/GPT-5 navigate complex sites, identify documents, understand relationships between statutes, regulations, forms.
 
 **AI techniques:** LLMs power intelligent crawling. Embedding models enable semantic search. NLP for classification and change detection. LLM benchmark using PolicyEngine-US across 10,000+ household scenarios. Rules-as-code generation experiments measuring LLM accuracy creating PolicyEngine parameter files with/without document access. MCP server for direct LLM integration.
@@ -13,6 +15,8 @@ AI crawlers understand government websites like human researchers. Claude/GPT-5 
 **Rules-as-Code Evaluation:** Building on Beeck Center's work, we'll test LLMs generating rules for PolicyEngine and Atlanta Fed systems. Three conditions: baseline (description only), enhanced (with documents), full (documents plus patterns). Expect 70%+ accuracy with documents versus <30% baseline.
 
 ## Data Strategy - Data Sources (250 words)
+
+**Word Count: 140/250**
 
 Data from public government websites only. Federal agencies (cms.gov, fns.usda.gov, acf.hhs.gov) publish regulations. State agencies host statutes, rules, forms. Never collect private data.
 
@@ -26,6 +30,8 @@ Data from public government websites only. Federal agencies (cms.gov, fns.usda.g
 
 ## Data Strategy - Data Management (250 words)
 
+**Word Count: 200/250**
+
 We ensure data quality through multiple validation layers. AI extracts documents with confidence scores; humans review low-confidence items additionally. Duplicate detection prevents redundant storage. Change tracking identifies true updates versus formatting changes. Automated testing verifies document accessibility and format integrity.
 
 **Representativeness:** We systematically cover all major benefit programs (SNAP, Medicaid, TANF, WIC, LIHEAP) across jurisdictions. Coverage dashboards identify gaps. Community can request missing documents via GitHub. Regular audits ensure comprehensive coverage without bias toward certain programs or states.
@@ -37,6 +43,8 @@ We ensure data quality through multiple validation layers. AI extracts documents
 **Quality metrics:** 99.5% accuracy target verified through sampling. Completeness tracked via coverage dashboards. Freshness monitored through update frequency. Community feedback incorporated via GitHub issues. This comprehensive approach ensures reliable, secure data management.
 
 ## Stakeholder Engagement (250 words)
+
+**Word Count: 172/250**
 
 Government partnerships through multiple channels. Federal Reserve Bank of Atlanta and Georgia Center for Opportunity collaboration demonstrates commitment—seeding library with documents covering all states/programs nationwide. Atlanta Fed helps test rules-as-code generation evaluation. OpenStates/Plural CEO expressed openness to collaboration, offering legislative tracking infrastructure.
 
@@ -50,6 +58,8 @@ Government partnerships through multiple channels. Federal Reserve Bank of Atlan
 
 ## Resources and Infrastructure (250 words)
 
+**Word Count: 228/250**
+
 Computational resources leverage cloud infrastructure for scalability. AWS provides core services: EC2 for crawlers, S3 for document storage, RDS for metadata. Infrastructure costs scale with usage, starting small and growing as coverage expands. AI API costs for Claude/GPT-5 vary based on crawling frequency and document volume.
 
 **Software stack:** Python for crawler development using LangChain for AI orchestration. Integration with PolicyEngine's open-source rules engine to identify relevant documents for eligibility decisions—our engine already maps complex relationships like TANF-SNAP categorical eligibility. OpenStates API v3 integration for legislative document access and schema compatibility. FastAPI for REST API development. MCP server for native LLM integration enabling tools like Claude to directly query policy documents during conversations. PostgreSQL for structured data. React for public dashboards. GitHub Actions for CI/CD. All components 100% open-source except AI services.
@@ -62,6 +72,8 @@ Computational resources leverage cloud infrastructure for scalability. AWS provi
 
 ## Scalability & Sustainability (250 words)
 
+**Word Count: 180/250**
+
 We build technical scalability into our architecture. Our crawler system uses job queues enabling horizontal scaling. Add more workers to handle more jurisdictions. Document storage in S3 scales infinitely. API uses caching and CDN for performance at scale. Database sharding ready for millions of documents.
 
 **Long-term sustainability through revenue diversification:** Enterprise API subscriptions from benefits platforms and government contractors. Government contracts for official preservation services. Foundation support for free nonprofit access. Multiple revenue streams ensure sustainability beyond grant period.
@@ -73,6 +85,8 @@ We build technical scalability into our architecture. Our crawler system uses jo
 **Technical evolution:** Architecture supports new AI models as they emerge. Jurisdiction-agnostic design enables international expansion. Modular components allow feature addition without system rewrites. Version control preserves all historical data. This comprehensive approach ensures the Policy Library becomes permanent infrastructure, not a temporary project.
 
 ## Financial Viability (250 words)
+
+**Word Count: 166/250**
 
 **Budget allocation:** Personnel (1.85 FTE): $293,000. Fringe benefits (33%): $96,690. Partner contracts including integration support: $164,000. AI tools and infrastructure: $60,000. Indirect costs (10% de minimis): $61,369. Total: $675,059.
 

--- a/src/content/pbif/applicationContent.ts
+++ b/src/content/pbif/applicationContent.ts
@@ -11,6 +11,8 @@ PolicyEngine Policy Library
 ## Executive Summary (limit 250 words)
 *"In a concise summary, describe the core problem your project addresses, the proposed technical solution, the target beneficiaries, and the anticipated impact."*
 
+**Word Count: 192/250**
+
 The Policy Library creates infrastructure transforming benefits delivery. When tools access comprehensive source documents, we enable: AI accurately determining multi-program eligibility, caseworkers confidently navigating rules, researchers tracking policy variations, and innovations we haven't imagined.
 
 We combine AI-powered monitoring (Claude/GPT-5) with PolicyEngine's open-source rules engine. We understand document relationships, surface non-obvious connections (TANF-SNAP categorical eligibility), enabling tools to build on authoritative ground truth.
@@ -37,13 +39,17 @@ export const valuePropositionContent = `# Section 2: Value Proposition and Respo
 ## Problem Statement (250 words)
 *"Clearly articulate the specific problem or challenge your initiative aims to address and how it relates to recent changes in federal policy or funding changes. Provide supporting data or evidence to demonstrate the urgency and significance of this problem - and how you've validated it with staff and/or beneficiaries. Is this an area where non-AI solutions do not already offer effective, fit-for-purpose, affordable approaches?"*
 
-The benefits ecosystem lacks foundational infrastructure for policy documentation, forcing every organization to rebuild document discovery and maintenance. This fragmentation prevents breakthrough innovations: AI tools can't provide accurate multi-program guidance without comprehensive documents, caseworkers can't confidently navigate complex eligibility rules, and researchers can't track policy evolution. Recent changes—SNAP work requirements, Medicaid unwinding, TANF time limits—make this infrastructure critical for system-wide transformation.
+**Word Count: 220/250**
 
-We validated this need through partnerships. MyFriendBen and Benefit Navigator spend resources maintaining document access instead of improving user experience. Georgetown and Michigan researchers lack the document foundation for policy analysis. The Federal Reserve Bank of Atlanta's Policy Rules Database collaboration shows even sophisticated institutions need shared infrastructure. Most critically, families navigating benefits face inconsistent information because no single source provides comprehensive, authoritative documentation.
+The benefits ecosystem lacks infrastructure for policy documentation, forcing organizations to rebuild document discovery. This prevents innovations: AI can't provide accurate multi-program guidance, caseworkers can't navigate eligibility rules, researchers can't track policy evolution. Recent changes—SNAP work requirements, Medicaid unwinding, TANF limits—make this critical.
 
-Why not use Archive.org? While excellent for general web preservation, Archive.org can't solve this problem: it captures pages indiscriminately without understanding what's a policy document, provides no API for benefits tools to query "Colorado SNAP rules," can't identify document relationships, and offers no metadata or semantic search. Benefits platforms need purpose-built infrastructure—structured data, reliable APIs, and intelligent document understanding. AI uniquely enables this: (1) Intelligent crawling understands which documents matter for benefits determination, (2) LLMs identify policy changes requiring immediate preservation, (3) AI surfaces non-obvious connections like TANF-SNAP categorical eligibility. Our testing shows Claude and GPT-5 excel at document extraction when properly prompted. This creates infrastructure that amplifies human expertise, enabling innovations impossible without comprehensive, structured document access.
+Partners validated this need. MyFriendBen and Benefit Navigator waste resources maintaining documents. Georgetown and Michigan researchers lack document foundations. Atlanta Fed's collaboration shows even sophisticated institutions need shared infrastructure. Families face inconsistent information without comprehensive documentation.
+
+Archive.org can't solve this: captures pages indiscriminately without understanding policy documents, no API for "Colorado SNAP rules" queries, can't identify document relationships, no metadata or semantic search. Benefits platforms need purpose-built infrastructure—structured data, reliable APIs, intelligent understanding. AI uniquely enables: (1) Intelligent crawling understands which documents matter, (2) LLMs identify changes requiring preservation, (3) AI surfaces non-obvious connections like TANF-SNAP categorical eligibility. Claude and GPT-5 excel at document extraction. This infrastructure amplifies human expertise, enabling impossible innovations.
 
 ## Solution & Target Beneficiaries (250 words)
+
+**Word Count: 244/250**
 
 The Policy Library solves document disappearance through three integrated components: (1) AI-powered crawlers using Claude/GPT-5 intelligently monitor government websites weekly, understanding context and document relationships; (2) Humans verify accuracy through GitHub pull requests; (3) Our stable API serves documents with permanent source IDs that never break. We'll launch with 5,000+ documents pooled from all participating organizations—PolicyEngine, Atlanta Fed, GCO, NBER (via TAXSIM MOU), Prenatal-to-3 Policy Impact Center at Vanderbilt, Better Government Lab, USC, MyFriendBen, and Benefit Navigator—ensuring comprehensive coverage from day one.
 
@@ -51,20 +57,164 @@ Vulnerable families navigating benefits currently lose access when documents dis
 
 Organizations serving these families also benefit significantly. Direct service providers save hours they currently waste maintaining broken links. Our system proactively monitors all document URLs and sends immediate alerts when links break, allowing partners to update references before users encounter errors. Benefits navigators access reliable documentation instantly. University researchers gain the ability to conduct longitudinal policy analysis. Government agencies benefit from permanent archives of their own historical documents.
 
-We involve beneficiaries throughout the project via: Monthly feedback sessions with partner organizations, open GitHub discussions for document requests, public dashboards showing coverage gaps, and direct integration with tools families already use. This participatory approach ensures we're building infrastructure that serves real needs, not theoretical ones.`;
+We involve beneficiaries throughout the project via: Monthly feedback sessions with partner organizations, open GitHub discussions for document requests, public dashboards showing coverage gaps, and direct integration with tools families already use. This participatory approach ensures we're building infrastructure that serves real needs, not theoretical ones.
+
+## Proposed Benefit and Impact Evaluation (250 words)
+
+**Word Count: 181/250**
+
+Our success transforms how America's safety net operates. Organizations shift from maintaining broken links to serving families. AI tools provide accurate benefit information. Families never lose benefits due to missing documents.
+
+Specific measurable metrics include:
+
+**Coverage metrics:** 90% of benefit programs documented by Month 6 (baseline: 5,000+ from partners), 50+ jurisdictions by Month 12, 100,000+ documents by Month 24.
+
+**Reliability metrics:** 99.9% API uptime, under 100ms retrieval speed, 99.5% accuracy via human verification.
+
+**Impact metrics:** MyFriendBen's 3,500 monthly Colorado users see primary sources; Riverside County's 500+ caseworkers access real-time verification. Rules engine integration ensures ALL relevant documents including non-obvious connections (TANF-SNAP eligibility). Track: document retrievals per partner, broken link reduction, time to resolve eligibility questions. LLM accuracy improvement of 24pp through test cases, including rules-as-code generation experiments (Beeck Center approach) comparing AI performance with/without primary sources—expecting significant improvement generating accurate PolicyEngine parameter files when LLMs reference actual statutes.
+
+We track progress through automated dashboards, monthly partner surveys, and API analytics. We publish quarterly reports sharing findings publicly. Success means families never hear "we can't find that document" when applying for benefits.
+
+## Responsible Design and Use (250 words)
+
+**Word Count: 192/250**
+
+We identify three key risks: privacy concerns, accuracy issues, and potential misuse. We address each proactively through technical and governance measures.
+
+**Privacy protection:** We archive only publicly available documents, never personal data. We don't collect or store user information. All documents we preserve already exist publicly. We respect robots.txt restrictions and rate limits to avoid overloading government servers.
+
+**Accuracy safeguards:** Humans review every document via GitHub pull requests before we include it. Version control tracks all changes. Community members report errors through GitHub issues. We maintain clear attribution and sourcing for every document. Regular audits verify continued accuracy.
+
+**Preventing misuse:** Clear terms of service prohibit using documents for fraud or misrepresentation. API rate limiting prevents abuse. We monitor usage patterns for anomalies. Documents include clear effective dates and jurisdiction markers to prevent confusion.
+
+**Transparency measures:** All crawler code is open-source for inspection. Document selection criteria are publicly documented. Coverage gaps are clearly marked. We publish regular transparency reports on what we're archiving and why. An advisory board including legal experts and benefits advocates provides oversight. These measures ensure the Policy Library serves its intended purpose: helping families access benefits, not enabling harm.
+
+## Adoption and Path to Scale (250 words)
+
+**Word Count: 238/250**
+
+Implementation builds on existing relationships. MyFriendBen already uses our API for 3,500+ monthly benefit calculations across Colorado—we'll add document display to these existing requests, showing users the actual regulations behind their results. Benefit Navigator, deployed with LA County caseworkers and expanding to Riverside County, will enhance their current PolicyEngine integration with primary-source verification during eligibility determinations. Each pilot receives $30k for deep technical integration and deployment support.
+
+Government partnership strategy leverages existing relationships. Federal Reserve Bank of Atlanta has committed to collaboration through their Policy Rules Database. North Carolina and California agencies expressed interest following our pilot success. We'll formalize partnerships through MOUs establishing data sharing agreements and technical integration plans.
+
+Community organization adoption follows a tiered approach. Tier 1: Direct integration partners (MyFriendBen, Benefit Navigator) who embed our API. Tier 2: Benefits navigators accessing through web interface. Tier 3: Researchers and advocates using public data. Each tier has tailored onboarding, documentation, and support.
+
+Sustainability comes through diversified support. Enterprise API subscriptions from large platforms generate recurring revenue. Government contracts for official preservation services provide stable funding. Foundation support maintains free access for nonprofits. Open-source model enables community contributions reducing costs.
+
+Scalability is built into architecture. Cloud infrastructure handles growth automatically. Crawler architecture is jurisdiction-agnostic, adding new states requires configuration not code. Community contributors can add coverage through pull requests. By Month 24, we'll cover all 50 states plus federal programs, becoming essential infrastructure for America's safety net.
+
+## Dissemination & Learning (250 words)
+
+**Word Count: 167/250**
+
+Knowledge sharing maximizes impact across the benefits ecosystem.
+
+**Open-source code:** All PolicyEngine code—rules engine, API, web app, document library—on GitHub under MIT license with 100+ contributors. Integration libraries (Python, JavaScript, R). Example implementations. Community contributes improvements, adds jurisdictions.
+
+**Public data access:** Document corpus via API with free tier. Bulk exports for researchers. Public dashboards showing coverage. Weekly Internet Archive dumps for preservation.
+
+**Learning dissemination:** Quarterly reports on policy patterns, preservation challenges, adoption metrics. LLM benchmark results showing accuracy improvements (baseline, with documents, with tools, full stack), including rules-as-code generation experiments demonstrating how primary sources enable accurate PolicyEngine parameter generation—extending Beeck Center's work. Academic papers on AI-powered benefits navigation. Conference presentations at Code for America Summit, Benefits Data Trust convening. Webinars for navigators and developers.
+
+**Community engagement:** Monthly calls for feedback. GitHub discussions for requests. Newsletter with updates. Documentation wiki.
+
+**Partnership sharing:** Case studies with MyFriendBen and Benefit Navigator. Research collaborations with Better Government Lab. Documentation of Atlanta Fed and GCO pilot learnings. Comprehensive dissemination ensures ecosystem-wide benefits.`;
 
 export const technicalFeasibilityContent = `# Section 3: Technical & Practical Feasibility
 
 ## Solution Description (250 words)
 
-The Policy Library uses AI as intelligent crawlers that understand government websites like human researchers. Claude and GPT-5 navigate complex site structures, identify relevant documents, and understand relationships between statutes, regulations, and forms. AI acts as our co-pilot while humans provide oversight at critical checkpoints.
+**Word Count: 198/250**
 
-**AI techniques:** Large language models (Claude/GPT-5) power intelligent crawling and document extraction. We prompt them to understand government website patterns, identify policy documents, and extract structured metadata. Embedding models for semantic search and duplicate detection. Traditional NLP for document classification and change detection. LLM benchmark framework using PolicyEngine-US to generate ground truth calculations across 10,000+ household scenarios, plus rules-as-code generation experiments measuring how accurately LLMs can create PolicyEngine parameter files with and without document access (building on Beeck Center's approach). MCP (Model Context Protocol) server enabling direct LLM integration for real-time policy lookups.
+AI crawlers understand government websites like human researchers. Claude/GPT-5 navigate complex sites, identify documents, understand relationships between statutes, regulations, forms.
 
-**Human oversight checkpoints:** (1) Initial crawler configuration: Humans define jurisdiction scope and document types. (2) Document identification: AI proposes documents, humans verify relevance via GitHub PR review. (3) Change detection: AI identifies updates, humans confirm significance. (4) Quality assurance: Regular human audits of AI decisions.
+**AI techniques:** LLMs power intelligent crawling. Embedding models enable semantic search. NLP for classification and change detection. LLM benchmark using PolicyEngine-US across 10,000+ household scenarios. Rules-as-code generation experiments measuring LLM accuracy creating PolicyEngine parameter files with/without document access. MCP server for direct LLM integration.
 
-**Architecture with Integration Support:** Crawler service using LangChain for AI orchestration. Continuous monitoring system checks all document URLs daily and sends immediate alerts to partners when links break. Web application enables document submission and retrieval beyond API access. We'll seed the system with documents from ALL confirmed partners: PolicyEngine's 2,500+ cited documents (from our 100% open-source rules engine with 100+ contributors), documents in Atlanta Fed's Policy Rules Database model (nationwide coverage of federal and state programs), GCO's comprehensive collection (all states and programs, not just NC), Prenatal-to-3 Policy Impact Center's research archive (they use PolicyEngine for state tax credit modeling), Better Government Lab and USC academic research, MyFriendBen's Colorado references, and Benefit Navigator's California documents—creating a comprehensive launch library of 5,000+ documents, all enriched with metadata and converted to plaintext for efficient AI processing. Our rules engine integration identifies the most relevant documents for any eligibility decision—including non-obvious connections like TANF regulations when TANF provides categorical eligibility for SNAP. REST API using FastAPI enhances existing partner integrations—MyFriendBen and Benefit Navigator add document display to their current PolicyEngine API calls. When Colorado users check benefits, they see actual state regulations. When Riverside County caseworkers verify eligibility, they access primary sources instantly. PostgreSQL for metadata, S3 for documents, CloudFlare CDN for performance.
+**Human oversight:** (1) Initial configuration, (2) Document verification via GitHub PR, (3) Change confirmation, (4) Regular audits.
 
-This hybrid approach leverages AI's ability to process vast amounts of information while maintaining human judgment for critical decisions, ensuring both scale and accuracy.
+**Architecture:** LangChain orchestration. Daily URL monitoring with partner alerts. Web app for document submission. Seeded with 5,000+ documents from partners: PolicyEngine (2,500+ citations), Atlanta Fed model (nationwide), GCO (all states/programs), NBER (tax documents since 2018 via TAXSIM MOU), Prenatal-to-3 Policy Impact Center, Better Government Lab, USC, MyFriendBen, Benefit Navigator. Rules engine identifies relevant documents including non-obvious connections (TANF-SNAP eligibility). FastAPI enhances partner integrations—MyFriendBen and Benefit Navigator add document display to existing API calls. PostgreSQL metadata, S3 storage, CloudFlare CDN.
 
-**Rules-as-Code Generation Evaluation:** Building on Beeck Center's pioneering work, we'll conduct controlled experiments measuring LLMs' ability to generate accurate rules-as-code for multiple open-source systems—PolicyEngine parameter files and Atlanta Fed Policy Rules Database entries (the only other open-source implementation). We'll test three conditions: (1) Baseline: LLM with only a policy description, (2) Enhanced: LLM with Policy Library document access, (3) Full: LLM with documents plus existing system patterns. We expect document-enhanced LLMs to achieve 70%+ accuracy in generating correct values, formulas, and effective dates—compared to under 30% baseline accuracy. This multi-system evaluation proves the Policy Library's universal value for automated policy implementation across different rules-as-code approaches.`;
+**Rules-as-Code Evaluation:** Building on Beeck Center's work, we'll test LLMs generating rules for PolicyEngine and Atlanta Fed systems. Three conditions: baseline (description only), enhanced (with documents), full (documents plus patterns). Expect 70%+ accuracy with documents versus <30% baseline.
+
+## Data Strategy - Data Sources (250 words)
+
+**Word Count: 140/250**
+
+Data from public government websites only. Federal agencies (cms.gov, fns.usda.gov, acf.hhs.gov) publish regulations. State agencies host statutes, rules, forms. Never collect private data.
+
+**Data ownership:** Public domain or government works. Clear attribution maintained. Our value-add creates new IP while respecting source rights.
+
+**Data agreements:** No formal agreements needed for public documents. Establishing MOUs with Federal Reserve Bank of Atlanta, North Carolina DHHS for collaboration and updates.
+
+**Securing access:** Responsible crawling: respecting robots.txt, rate limits, identifying via user agent. Agencies can push updates directly. Several expressed interest during pilot.
+
+**Pilot validation:** North Carolina pilot proved feasibility archiving SNAP, Medicaid, TANF documents. Federal sites more standardized. Partner contributions: PolicyEngine (2,500+ citations), Atlanta Fed model (nationwide), GCO (all states/programs), NBER (tax documents since 2018), Prenatal-to-3 at Vanderbilt, Better Government Lab, USC, MyFriendBen, Benefit Navigator. Collaborative seeding ensures comprehensive coverage while eliminating privacy concerns.
+
+## Data Strategy - Data Management (250 words)
+
+**Word Count: 200/250**
+
+We ensure data quality through multiple validation layers. AI extracts documents with confidence scores; humans review low-confidence items additionally. Duplicate detection prevents redundant storage. Change tracking identifies true updates versus formatting changes. Automated testing verifies document accessibility and format integrity.
+
+**Representativeness:** We systematically cover all major benefit programs (SNAP, Medicaid, TANF, WIC, LIHEAP) across jurisdictions. Coverage dashboards identify gaps. Community can request missing documents via GitHub. Regular audits ensure comprehensive coverage without bias toward certain programs or states.
+
+**Privacy safeguards:** We scan documents for personally identifiable information before storage; any PII triggers manual review. We collect no user data. API access remains anonymous beyond basic rate limiting. While documents already exist publicly, we add extra screening to prevent accidental inclusion of private data.
+
+**Security measures:** Documents stored in S3 with encryption at rest. API uses TLS for transit encryption. Access controls limit write permissions to verified contributors. Version control in GitHub provides audit trail. Regular security scans check for vulnerabilities. Backup copies in multiple regions prevent data loss.
+
+**Quality metrics:** 99.5% accuracy target verified through sampling. Completeness tracked via coverage dashboards. Freshness monitored through update frequency. Community feedback incorporated via GitHub issues. This comprehensive approach ensures reliable, secure data management.
+
+## Stakeholder Engagement (250 words)
+
+**Word Count: 172/250**
+
+Government partnerships through multiple channels. Federal Reserve Bank of Atlanta and Georgia Center for Opportunity collaboration demonstrates commitment—seeding library with documents covering all states/programs nationwide. Atlanta Fed helps test rules-as-code generation evaluation. OpenStates/Plural CEO expressed openness to collaboration, offering legislative tracking infrastructure.
+
+**Civic tech engagement:** Partner with former Code for America brigades for infrastructure support. Volunteer technologists identify missing documents, contribute crawlers, validate quality. Distributed model ensures comprehensive coverage with local ownership.
+
+**Direct service partnership:** MyFriendBen and Benefit Navigator staff participate monthly, test features, provide feedback. Frontline experience guides prioritization.
+
+**Academic collaboration:** Better Government Lab and USC contribute expertise and documents from PolicyEngine research. NBER contributes assembled tax documents through TAXSIM MOU covering historical policies since 2018. Prenatal-to-3 at Vanderbilt uses PolicyEngine for tax credit modeling, contributes research archive. Georgetown and Michigan teams provide academic rigor. Researchers use archive for economic analysis.
+
+**Open source ecosystem:** All code public. Work with 8-10 rules-as-code organizations via RFP—state agencies, research institutions, civic tech groups contributing documents. Documentation encourages adaptation. Transparency builds trust and ensures sustainability.
+
+## Resources and Infrastructure (250 words)
+
+**Word Count: 228/250**
+
+Computational resources leverage cloud infrastructure for scalability. AWS provides core services: EC2 for crawlers, S3 for document storage, RDS for metadata. Infrastructure costs scale with usage, starting small and growing as coverage expands. AI API costs for Claude/GPT-5 vary based on crawling frequency and document volume.
+
+**Software stack:** Python for crawler development using LangChain for AI orchestration. Integration with PolicyEngine's open-source rules engine to identify relevant documents for eligibility decisions—our engine already maps complex relationships like TANF-SNAP categorical eligibility. OpenStates API v3 integration for legislative document access and schema compatibility. FastAPI for REST API development. MCP server for native LLM integration enabling tools like Claude to directly query policy documents during conversations. PostgreSQL for structured data. React for public dashboards. GitHub Actions for CI/CD. All components 100% open-source except AI services.
+
+**Government system integration:** API-first architecture enables integration without direct system access. Partners embed via REST calls or JavaScript widgets. Government agencies can bulk export their documents. No direct database connections required, reducing security concerns and technical barriers.
+
+**Access model:** CloudFlare CDN ensures global availability with low latency. Multiple availability zones prevent outages. Automated scaling handles traffic spikes. API gateway manages authentication and rate limiting.
+
+**Development infrastructure:** GitHub for code repository and collaboration. Slack for team communication. Linear for project management. Datadog for monitoring. This modern stack ensures efficient development and reliable operations while remaining vendor-agnostic where possible.
+
+## Scalability & Sustainability (250 words)
+
+**Word Count: 180/250**
+
+We build technical scalability into our architecture. Our crawler system uses job queues enabling horizontal scaling. Add more workers to handle more jurisdictions. Document storage in S3 scales infinitely. API uses caching and CDN for performance at scale. Database sharding ready for millions of documents.
+
+**Long-term sustainability through revenue diversification:** Enterprise API subscriptions from benefits platforms and government contractors. Government contracts for official preservation services. Foundation support for free nonprofit access. Multiple revenue streams ensure sustainability beyond grant period.
+
+**Cost optimization:** Open-source approach eliminates licensing costs. Community contributions from 100+ developers reduce development expenses. Efficient caching minimizes AI API usage. Graduated storage (hot/cold) optimizes costs for historical documents.
+
+**Organizational sustainability:** PolicyEngine's existing infrastructure and team provide stable foundation. Policy Library enhances our core benefits calculator mission. Board commitment to long-term support. Partnership agreements ensure continued stakeholder investment.
+
+**Technical evolution:** Architecture supports new AI models as they emerge. Jurisdiction-agnostic design enables international expansion. Modular components allow feature addition without system rewrites. Version control preserves all historical data. This comprehensive approach ensures the Policy Library becomes permanent infrastructure, not a temporary project.
+
+## Financial Viability (250 words)
+
+**Word Count: 166/250**
+
+**Budget allocation:** Personnel (1.85 FTE): $293,000. Fringe benefits (33%): $96,690. Partner contracts including integration support: $164,000. AI tools and infrastructure: $60,000. Indirect costs (10% de minimis): $61,369. Total: $675,059.
+
+The PBIF grant enables dedicated Policy Library development while PolicyEngine maintains its existing benefits calculator services. This focused investment creates infrastructure that becomes self-sustaining through API subscriptions and government contracts.
+
+**Funding diversification:** PBIF funding jumpstarts development. By Year 2, we anticipate enterprise API subscriptions and government preservation contracts. The open-source model and community contributions reduce ongoing costs.
+
+**Financial sustainability plan:** Year 1: PBIF funding covers development and initial deployment with 5,000+ seed documents from partners. Year 2: Begin enterprise subscriptions and government contracts as system proves value. Year 3: Achieve sustainability through diversified revenue including API subscriptions, government contracts, and foundation support.
+
+**Risk mitigation:** Staggered hiring reduces upfront costs. Cloud infrastructure scales with usage. Open-source model enables community contributions. Multiple revenue streams prevent single points of failure. This pragmatic approach ensures financial viability while building critical infrastructure.`;

--- a/sync_markdown_to_ts.py
+++ b/sync_markdown_to_ts.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Sync markdown content to TypeScript applicationContent.ts file."""
+
+from pathlib import Path
+
+def read_markdown_file(filepath):
+    """Read and return markdown file content."""
+    with open(filepath, 'r') as f:
+        return f.read()
+
+def main():
+    base_path = Path("src/content/pbif")
+    
+    # Read markdown files
+    executive_summary = read_markdown_file(base_path / "01-executive-summary.md")
+    value_proposition = read_markdown_file(base_path / "02-value-proposition.md")
+    technical_feasibility = read_markdown_file(base_path / "03-technical-feasibility.md")
+    
+    # Generate TypeScript content
+    ts_content = f'''export const executiveSummaryContent = `{executive_summary}`;
+
+export const valuePropositionContent = `{value_proposition}`;
+
+export const technicalFeasibilityContent = `{technical_feasibility}`;
+'''
+    
+    # Write to TypeScript file
+    ts_path = base_path / "applicationContent.ts"
+    with open(ts_path, 'w') as f:
+        f.write(ts_content)
+    
+    print(f"✅ Updated {ts_path} with content from markdown files including word counts")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds word count displays to all PBIF application sections so they're visible on the website.

## Changes
- Added 'Word Count: X/250' to each section that has a 250-word limit
- All sections confirmed within limits:
  - Executive Summary: 192/250 ✅
  - Problem Statement: 220/250 ✅
  - Solution & Target Beneficiaries: 244/250 ✅
  - Proposed Benefit and Impact: 181/250 ✅
  - Responsible Design and Use: 192/250 ✅
  - Adoption and Path to Scale: 238/250 ✅
  - Dissemination & Learning: 167/250 ✅
  - Solution Description: 198/250 ✅
  - Data Strategy - Sources: 140/250 ✅
  - Data Strategy - Management: 200/250 ✅
  - Stakeholder Engagement: 172/250 ✅
  - Resources and Infrastructure: 228/250 ✅
  - Scalability & Sustainability: 180/250 ✅
  - Financial Viability: 166/250 ✅

## Implementation
- Updated markdown files with word counts
- Created sync script to update TypeScript content file
- Word counts now visible at https://policyengine.github.io/policy-library/application

🤖 Generated with [Claude Code](https://claude.ai/code)