### PR TITLE
Add all contributing organizations to executive summary

### DIFF
--- a/src/content/pbif/01-executive-summary.md
+++ b/src/content/pbif/01-executive-summary.md
@@ -11,7 +11,7 @@ PolicyEngine Policy Library
 ## Executive Summary (limit 250 words)
 *"In a concise summary, describe the core problem your project addresses, the proposed technical solution, the target beneficiaries, and the anticipated impact."*
 
-**Word Count: 205/250**
+**Word Count: 212/250**
 
 The Policy Library creates infrastructure transforming benefits delivery. When tools access comprehensive source documents, we enable: AI accurately determining multi-program eligibility, caseworkers confidently navigating rules, researchers tracking policy variations, and innovations we haven't imagined.
 
@@ -19,7 +19,7 @@ We combine AI-powered monitoring (Claude/GPT-5) with PolicyEngine's open-source 
 
 **PBIF Priority Impact:** Income verification via state-specific disregards; reduced SNAP errors through current criteria; confident beneficiary communication with source documents; backlog reduction saving staff time.
 
-**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta, Georgia Center for Opportunity, and NBER continues—we seed the library with documents covering nationwide scope. NBER and Prenatal-to-3 already use PolicyEngine for tax credit modeling. MyFriendBen, Benefit Navigator, Mirza, and Impactica use our API—we'll add document display to existing requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
+**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta, Georgia Center for Opportunity, NBER, Prenatal-to-3, Better Government Lab, USC, MyFriendBen, and Benefit Navigator continues—we seed the library with documents covering nationwide scope. NBER and Prenatal-to-3 already use PolicyEngine for tax credit modeling; Mirza and Impactica use our API. We'll add document display to existing API requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
 
 **12-month timeline:** Months 1-3: Launch 5,000+ documents, 10 states; Months 4-6: API v1 with partners; Months 7-9: 30 states; Months 10-12: Full production covering 50+ jurisdictions.
 

--- a/src/content/pbif/01-executive-summary.md
+++ b/src/content/pbif/01-executive-summary.md
@@ -11,7 +11,7 @@ PolicyEngine Policy Library
 ## Executive Summary (limit 250 words)
 *"In a concise summary, describe the core problem your project addresses, the proposed technical solution, the target beneficiaries, and the anticipated impact."*
 
-**Word Count: 192/250**
+**Word Count: 205/250**
 
 The Policy Library creates infrastructure transforming benefits delivery. When tools access comprehensive source documents, we enable: AI accurately determining multi-program eligibility, caseworkers confidently navigating rules, researchers tracking policy variations, and innovations we haven't imagined.
 
@@ -19,7 +19,7 @@ We combine AI-powered monitoring (Claude/GPT-5) with PolicyEngine's open-source 
 
 **PBIF Priority Impact:** Income verification via state-specific disregards; reduced SNAP errors through current criteria; confident beneficiary communication with source documents; backlog reduction saving staff time.
 
-**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta and Georgia Center for Opportunity continues—we seed the library with documents covering nationwide scope. MyFriendBen and Benefit Navigator already use our API—we'll add document display to existing requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
+**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta, Georgia Center for Opportunity, and NBER continues—we seed the library with documents covering nationwide scope. NBER and Prenatal-to-3 already use PolicyEngine for tax credit modeling. MyFriendBen, Benefit Navigator, Mirza, and Impactica use our API—we'll add document display to existing requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
 
 **12-month timeline:** Months 1-3: Launch 5,000+ documents, 10 states; Months 4-6: API v1 with partners; Months 7-9: 30 states; Months 10-12: Full production covering 50+ jurisdictions.
 

--- a/src/content/pbif/applicationContent.ts
+++ b/src/content/pbif/applicationContent.ts
@@ -11,7 +11,7 @@ PolicyEngine Policy Library
 ## Executive Summary (limit 250 words)
 *"In a concise summary, describe the core problem your project addresses, the proposed technical solution, the target beneficiaries, and the anticipated impact."*
 
-**Word Count: 205/250**
+**Word Count: 212/250**
 
 The Policy Library creates infrastructure transforming benefits delivery. When tools access comprehensive source documents, we enable: AI accurately determining multi-program eligibility, caseworkers confidently navigating rules, researchers tracking policy variations, and innovations we haven't imagined.
 
@@ -19,7 +19,7 @@ We combine AI-powered monitoring (Claude/GPT-5) with PolicyEngine's open-source 
 
 **PBIF Priority Impact:** Income verification via state-specific disregards; reduced SNAP errors through current criteria; confident beneficiary communication with source documents; backlog reduction saving staff time.
 
-**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta, Georgia Center for Opportunity, and NBER continues—we seed the library with documents covering nationwide scope. NBER and Prenatal-to-3 already use PolicyEngine for tax credit modeling. MyFriendBen, Benefit Navigator, Mirza, and Impactica use our API—we'll add document display to existing requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
+**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta, Georgia Center for Opportunity, NBER, Prenatal-to-3, Better Government Lab, USC, MyFriendBen, and Benefit Navigator continues—we seed the library with documents covering nationwide scope. NBER and Prenatal-to-3 already use PolicyEngine for tax credit modeling; Mirza and Impactica use our API. We'll add document display to existing API requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
 
 **12-month timeline:** Months 1-3: Launch 5,000+ documents, 10 states; Months 4-6: API v1 with partners; Months 7-9: 30 states; Months 10-12: Full production covering 50+ jurisdictions.
 

--- a/src/content/pbif/applicationContent.ts
+++ b/src/content/pbif/applicationContent.ts
@@ -11,7 +11,7 @@ PolicyEngine Policy Library
 ## Executive Summary (limit 250 words)
 *"In a concise summary, describe the core problem your project addresses, the proposed technical solution, the target beneficiaries, and the anticipated impact."*
 
-**Word Count: 192/250**
+**Word Count: 205/250**
 
 The Policy Library creates infrastructure transforming benefits delivery. When tools access comprehensive source documents, we enable: AI accurately determining multi-program eligibility, caseworkers confidently navigating rules, researchers tracking policy variations, and innovations we haven't imagined.
 
@@ -19,7 +19,7 @@ We combine AI-powered monitoring (Claude/GPT-5) with PolicyEngine's open-source 
 
 **PBIF Priority Impact:** Income verification via state-specific disregards; reduced SNAP errors through current criteria; confident beneficiary communication with source documents; backlog reduction saving staff time.
 
-**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta and Georgia Center for Opportunity continues—we seed the library with documents covering nationwide scope. MyFriendBen and Benefit Navigator already use our API—we'll add document display to existing requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
+**Not starting from scratch:** Collaboration with Federal Reserve Bank of Atlanta, Georgia Center for Opportunity, and NBER continues—we seed the library with documents covering nationwide scope. NBER and Prenatal-to-3 already use PolicyEngine for tax credit modeling. MyFriendBen, Benefit Navigator, Mirza, and Impactica use our API—we'll add document display to existing requests and integrate into caseworker training. Colorado users and Riverside County caseworkers see primary sources alongside calculations.
 
 **12-month timeline:** Months 1-3: Launch 5,000+ documents, 10 states; Months 4-6: API v1 with partners; Months 7-9: 30 states; Months 10-12: Full production covering 50+ jurisdictions.
 


### PR DESCRIPTION
## Summary
Updates the executive summary to properly list all 8 contributing organizations and clarify their relationships with PolicyEngine.

## Changes
- **Main collaboration statement** now includes all 8 organizations:
  - Federal Reserve Bank of Atlanta
  - Georgia Center for Opportunity
  - NBER
  - Prenatal-to-3 Policy Impact Center
  - Better Government Lab
  - USC
  - MyFriendBen
  - Benefit Navigator

- **Clarified relationships:**
  - NBER and Prenatal-to-3 use PolicyEngine for tax credit modeling
  - Mirza and Impactica are API users
  - All organizations contribute documents to seed the library

- **Word count:** 212/250 (still within limit)

This ensures the executive summary accurately reflects the depth and breadth of our partnerships.

🤖 Generated with [Claude Code](https://claude.ai/code)